### PR TITLE
Properly handle dual-class State/Props setups

### DIFF
--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -215,14 +215,14 @@ class ParsedDeclarations {
       stateCompanion = companionMap[state.name.name];
     }
 
-    Iterable<ClassDeclaration> pairClassWithCompanion(ClassDeclaration cd)
+    List<ClassDeclaration> pairClassWithCompanion(ClassDeclaration cd)
       => companionMap.containsKey(cd.name.name) ? [cd, companionMap[cd.name.name]] : [cd];
 
     final List<ClassDeclaration> abstractProps = declarationMap[key_abstractProps];
-    final abstractPropsPairs = abstractProps.map(pairClassWithCompanion);
+    final abstractPropsPairs = abstractProps.map(pairClassWithCompanion).toList();
 
     final List<ClassDeclaration> abstractStates = declarationMap[key_abstractState];
-    final abstractStatePairs = abstractStates.map(pairClassWithCompanion);
+    final abstractStatePairs = abstractStates.map(pairClassWithCompanion).toList();
 
     return new ParsedDeclarations._(
         factory:        singleOrNull(declarationMap[key_factory]),

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -53,27 +53,30 @@ class ParsedDeclarations {
       key_stateMixin:        <CompilationUnitMember>[],
     };
 
+    Map<String /* class name */, ClassDeclaration> companionMap = {};
+
     unit.declarations.forEach((CompilationUnitMember member) {
       member.metadata.forEach((annotation) {
         var name = annotation.name.toString();
-        var publicMember;
 
         if (name == 'Props' || name == 'State' || name == 'AbstractProps' || name == 'AbstractState') {
           if (member is ClassDeclaration && member.name.name.startsWith('_\$')) {
-            var matchingPublicPropsOrStateClasses =
-              unit.declarations.where((CompilationUnitMember innerLoopMember) =>
-                innerLoopMember is ClassDeclaration && member.name.name.substring(2) == innerLoopMember.name.name);
+            final className = member.name.name;
+            final companionName = member.name.name.substring(2);
+            final companionClass = unit.declarations.firstWhere(
+              (innerLoopMember) => innerLoopMember is ClassDeclaration && innerLoopMember.name.name == companionName,
+              orElse: () => null);
 
-            if (matchingPublicPropsOrStateClasses.isEmpty) {
+            if (companionClass == null) {
               error('${member.name.name} must have an accompanying public class within the '
                   'same file for Dart 2 builder compatibility, but one was not found.', getSpan(sourceFile, member));
             } else {
-              publicMember = matchingPublicPropsOrStateClasses.first;
+              companionMap[className] = companionClass;
             }
           }
         }
 
-        declarationMap[name]?.add(publicMember ?? member);
+        declarationMap[name]?.add(member);
       });
     });
 
@@ -200,18 +203,40 @@ class ParsedDeclarations {
       });
     }
 
+    final ClassDeclaration props = singleOrNull(declarationMap[key_props]);
+    var propsCompanion;
+    if (props != null && companionMap.containsKey(props.name.name)) {
+      propsCompanion = companionMap[props.name.name];
+    }
+
+    final ClassDeclaration state = singleOrNull(declarationMap[key_state]);
+    var stateCompanion;
+    if (state != null && companionMap.containsKey(state.name.name)) {
+      stateCompanion = companionMap[state.name.name];
+    }
+
+    Iterable<ClassDeclaration> pairClassWithCompanion(ClassDeclaration cd)
+      => companionMap.containsKey(cd.name.name) ? [cd, companionMap[cd.name.name]] : [cd];
+
+    final List<ClassDeclaration> abstractProps = declarationMap[key_abstractProps];
+    final abstractPropsPairs = abstractProps.map(pairClassWithCompanion);
+
+    final List<ClassDeclaration> abstractStates = declarationMap[key_abstractState];
+    final abstractStatePairs = abstractStates.map(pairClassWithCompanion);
 
     return new ParsedDeclarations._(
-        factory:       singleOrNull(declarationMap[key_factory]),
-        component:     singleOrNull(declarationMap[key_component]),
-        props:         singleOrNull(declarationMap[key_props]),
-        state:         singleOrNull(declarationMap[key_state]),
+        factory:        singleOrNull(declarationMap[key_factory]),
+        component:      singleOrNull(declarationMap[key_component]),
+        props:          props,
+        propsCompanion: propsCompanion,
+        state:          state,
+        stateCompanion: stateCompanion,
 
-        abstractProps: declarationMap[key_abstractProps],
-        abstractState: declarationMap[key_abstractState],
+        abstractProps:  abstractPropsPairs,
+        abstractState:  abstractStatePairs,
 
-        propsMixins:   declarationMap[key_propsMixin],
-        stateMixins:   declarationMap[key_stateMixin],
+        propsMixins:    declarationMap[key_propsMixin],
+        stateMixins:    declarationMap[key_stateMixin],
 
         hasErrors: hasErrors
     );
@@ -221,26 +246,28 @@ class ParsedDeclarations {
       TopLevelVariableDeclaration factory,
       ClassDeclaration component,
       ClassDeclaration props,
+      ClassDeclaration propsCompanion,
       ClassDeclaration state,
+      ClassDeclaration stateCompanion,
 
-      List<ClassDeclaration> abstractProps,
-      List<ClassDeclaration> abstractState,
+      List<List<ClassDeclaration>> abstractProps,
+      List<List<ClassDeclaration>> abstractState,
 
       List<ClassDeclaration> propsMixins,
       List<ClassDeclaration> stateMixins,
 
       this.hasErrors
   }) :
-      this.factory       = (factory   == null) ? null : new FactoryNode(factory),
-      this.component     = (component == null) ? null : new ComponentNode(component),
-      this.props         = (props     == null) ? null : new PropsNode(props),
-      this.state         = (state     == null) ? null : new StateNode(state),
+      this.factory        = (factory        == null) ? null : new FactoryNode(factory),
+      this.component      = (component      == null) ? null : new ComponentNode(component),
+      this.props          = (props          == null) ? null : new PropsNode(props, propsCompanion),
+      this.state          = (state          == null) ? null : new StateNode(state, stateCompanion),
 
-      this.abstractProps = new List.unmodifiable(abstractProps.map((propsMixin) => new AbstractPropsNode(propsMixin))),
-      this.abstractState = new List.unmodifiable(abstractState.map((stateMixin) => new AbstractStateNode(stateMixin))),
+      this.abstractProps  = new List.unmodifiable(abstractProps.map((nodes) => new AbstractPropsNode(nodes[0], nodes.length > 1 ? nodes[1] : null))),
+      this.abstractState  = new List.unmodifiable(abstractState.map((nodes) => new AbstractStateNode(nodes[0], nodes.length > 1 ? nodes[1] : null))),
 
-      this.propsMixins   = new List.unmodifiable(propsMixins.map((propsMixin) => new PropsMixinNode(propsMixin))),
-      this.stateMixins   = new List.unmodifiable(stateMixins.map((stateMixin) => new StateMixinNode(stateMixin))),
+      this.propsMixins    = new List.unmodifiable(propsMixins.map((propsMixin) => new PropsMixinNode(propsMixin))),
+      this.stateMixins    = new List.unmodifiable(stateMixins.map((stateMixin) => new StateMixinNode(stateMixin))),
 
       this.declaresComponent = factory != null
   {
@@ -346,12 +373,20 @@ class ComponentNode extends NodeWithMeta<ClassDeclaration, annotations.Component
   }
 }
 
-class FactoryNode           extends NodeWithMeta<TopLevelVariableDeclaration, annotations.Factory> {FactoryNode(unit)           : super(unit);}
-class PropsNode             extends NodeWithMeta<ClassDeclaration, annotations.Props>              {PropsNode(unit)             : super(unit);}
-class StateNode             extends NodeWithMeta<ClassDeclaration, annotations.State>              {StateNode(unit)             : super(unit);}
+class NodeWithMetaAndCompanion<TNode extends AnnotatedNode, TMeta> extends NodeWithMeta<TNode, TMeta> {
+  /// The companion node for classes that require a dual-class setup during the
+  /// Dart1 -> Dart2 transition.
+  final TNode companionNode;
 
-class AbstractPropsNode     extends NodeWithMeta<ClassDeclaration, annotations.AbstractProps>      {AbstractPropsNode(unit)     : super(unit);}
-class AbstractStateNode     extends NodeWithMeta<ClassDeclaration, annotations.AbstractState>      {AbstractStateNode(unit)     : super(unit);}
+  NodeWithMetaAndCompanion(unit, {this.companionNode}) : super(unit);
+}
 
-class PropsMixinNode        extends NodeWithMeta<ClassDeclaration, annotations.PropsMixin>         {PropsMixinNode(unit)        : super(unit);}
-class StateMixinNode        extends NodeWithMeta<ClassDeclaration, annotations.StateMixin>         {StateMixinNode(unit)        : super(unit);}
+class FactoryNode       extends NodeWithMeta<TopLevelVariableDeclaration, annotations.Factory>        {FactoryNode(unit)                : super(unit);}
+class PropsNode         extends NodeWithMetaAndCompanion<ClassDeclaration, annotations.Props>         {PropsNode(unit, [cUnit])         : super(unit, companionNode: cUnit);}
+class StateNode         extends NodeWithMetaAndCompanion<ClassDeclaration, annotations.State>         {StateNode(unit, [cUnit])         : super(unit, companionNode: cUnit);}
+
+class AbstractPropsNode extends NodeWithMetaAndCompanion<ClassDeclaration, annotations.AbstractProps> {AbstractPropsNode(unit, [cUnit]) : super(unit, companionNode: cUnit);}
+class AbstractStateNode extends NodeWithMetaAndCompanion<ClassDeclaration, annotations.AbstractState> {AbstractStateNode(unit, [cUnit]) : super(unit, companionNode: cUnit);}
+
+class PropsMixinNode    extends NodeWithMeta<ClassDeclaration, annotations.PropsMixin>                {PropsMixinNode(unit)             : super(unit);}
+class StateMixinNode    extends NodeWithMeta<ClassDeclaration, annotations.StateMixin>                {StateMixinNode(unit)             : super(unit);}

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -130,6 +130,7 @@ main() {
 
           expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
           expect(declarations.props.node?.name?.name, 'FooProps');
+          expect(declarations.props.companionNode, isNull);
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
           expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
@@ -140,7 +141,7 @@ main() {
           expect(declarations.declaresComponent, isTrue);
         });
 
-        test('a component with builder compatible annotated private props class', () {
+        test('a component with builder-compatible dual-class props setup', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
             class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {}
@@ -149,11 +150,12 @@ main() {
           ''');
 
           expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
-          expect(declarations.props.node?.name?.name, 'FooProps');
+          expect(declarations.props.node?.name?.name, '_\$FooProps');
+          expect(declarations.props.companionNode?.name?.name, 'FooProps');
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
           expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
-          expect(declarations.props.meta,     isNull);
+          expect(declarations.props.meta,     const isInstanceOf<annotations.Props>());
           expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
 
           expectEmptyDeclarations(factory: false, props: false, component: false);
@@ -170,7 +172,9 @@ main() {
 
           expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
           expect(declarations.props.node?.name?.name, 'FooProps');
+          expect(declarations.props.companionNode, isNull);
           expect(declarations.state.node?.name?.name, 'FooState');
+          expect(declarations.state.companionNode, isNull);
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
           expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
@@ -182,7 +186,7 @@ main() {
           expect(declarations.declaresComponent, isTrue);
         });
 
-        test('a stateful component with builder compatible annotated private state class', () {
+        test('a stateful component with builder-compatible dual-class state setup', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
             @Props()      class FooProps {}
@@ -193,12 +197,14 @@ main() {
 
           expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
           expect(declarations.props.node?.name?.name, 'FooProps');
-          expect(declarations.state.node?.name?.name, 'FooState');
+          expect(declarations.props.companionNode, isNull);
+          expect(declarations.state.node?.name?.name, '_\$FooState');
+          expect(declarations.state.companionNode?.name?.name, 'FooState');
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
           expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
           expect(declarations.props.meta,     const isInstanceOf<annotations.Props>());
-          expect(declarations.state.meta,     isNull);
+          expect(declarations.state.meta,     const isInstanceOf<annotations.State>());
           expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
 
           expectEmptyDeclarations(factory: false, props: false, state: false, component: false);
@@ -248,12 +254,26 @@ main() {
           expect(declarations.abstractProps, hasLength(2));
 
           expect(declarations.abstractProps[0].node.name.name, 'AbstractFooProps1');
+          expect(declarations.abstractProps[0].companionNode, isNull);
           expect(declarations.abstractProps[1].node.name.name, 'AbstractFooProps2');
+          expect(declarations.abstractProps[1].companionNode, isNull);
           expect(declarations.abstractProps[0].meta, new isInstanceOf<annotations.AbstractProps>());
           expect(declarations.abstractProps[1].meta, new isInstanceOf<annotations.AbstractProps>());
 
           expectEmptyDeclarations(abstractProps: false);
           expect(declarations.declaresComponent, isFalse);
+        });
+
+        test('abstract props class with builder-compatible dual-class setup', () {
+          setUpAndParse('''
+            @AbstractProps() class _\$AbstractFooProps {}
+            class AbstractFooProps {}
+          ''');
+
+          expect(declarations.abstractProps, hasLength(1));
+          expect(declarations.abstractProps[0].node?.name?.name, '_\$AbstractFooProps');
+          expect(declarations.abstractProps[0].companionNode?.name?.name, 'AbstractFooProps');
+          expect(declarations.abstractProps[0].meta, new isInstanceOf<annotations.AbstractProps>());
         });
 
         test('abstract state classes', () {
@@ -265,12 +285,26 @@ main() {
           expect(declarations.abstractState, hasLength(2));
 
           expect(declarations.abstractState[0].node.name.name, 'AbstractFooState1');
+          expect(declarations.abstractState[0].companionNode, isNull);
           expect(declarations.abstractState[1].node.name.name, 'AbstractFooState2');
+          expect(declarations.abstractState[1].companionNode, isNull);
           expect(declarations.abstractState[0].meta, new isInstanceOf<annotations.AbstractState>());
           expect(declarations.abstractState[1].meta, new isInstanceOf<annotations.AbstractState>());
 
           expectEmptyDeclarations(abstractState: false);
           expect(declarations.declaresComponent, isFalse);
+        });
+
+        test('abstract state class with builder-compatible dual-class setup', () {
+          setUpAndParse('''
+            @AbstractState() class _\$AbstractFooState {}
+            class AbstractFooState {}
+          ''');
+
+          expect(declarations.abstractState, hasLength(1));
+          expect(declarations.abstractState[0].node?.name?.name, '_\$AbstractFooState');
+          expect(declarations.abstractState[0].companionNode?.name?.name, 'AbstractFooState');
+          expect(declarations.abstractState[0].meta, new isInstanceOf<annotations.AbstractState>());
         });
 
         group('and initializes annotations with the correct arguments for', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -350,8 +350,8 @@ main() {
           expect(transformedSource, contains(transformedLine));
         });
 
-        test('with builder compatible private props class', () {
-          final originalPrivateFooPropsLine = 'class _\$FooProps extends UiProps {}';
+        test('with builder-compatible dual-class props setup', () {
+          final originalPrivateFooPropsLine = 'class _\$FooProps extends UiProps {';
           final originalPublicFooPropsLine = 'class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {';
           final transformedFooPropsLine = 'class FooProps extends _\$FooProps';
           final fooPropsImplExtendsPublicClass = 'class _\$FooPropsImpl extends FooProps';
@@ -392,8 +392,8 @@ main() {
           expect(transformedSource, isNot(contains(fooPropsImplExtendsPrivateClass)));
         });
 
-        test('with builder compatible private state class', () {
-          final originalPrivateFooStateLine = 'class _\$FooState extends UiState {}';
+        test('with builder-compatible dual-class state setup', () {
+          final originalPrivateFooStateLine = 'class _\$FooState extends UiState {';
           final originalPublicFooStateLine = 'class FooState extends _\$FooState with _\$FooStateAccessorsMixin {';
           final transformedFooStateLine = 'class FooState extends _\$FooState';
           final fooStateImplExtendsPublicClass = 'class _\$FooStateImpl extends FooState';
@@ -429,7 +429,7 @@ main() {
           expect(transformedSource, isNot(contains(fooStateImplExtendsPrivateClass)));
         });
 
-        test('with builder compatible private abstract props class', () {
+        test('with builder-compatible dual-class abstract props setup', () {
           final originalPrivateClassLine = 'class _\$AbstractFooProps {';
           final originalPublicClassLine = 'class AbstractFooProps extends _\$AbstractFooProps with _\$AbstractFooPropsAccessorsMixin {';
           final transformedFooStateLine = 'class AbstractFooProps extends _\$AbstractFooProps';
@@ -465,7 +465,7 @@ main() {
           expect(transformedSource, contains(transformedFooStateLine));
         });
 
-        test('with builder compatible private abstract state class', () {
+        test('with builder-compatible dual-class abstract state setup', () {
           final originalPrivateClassLine = 'class _\$AbstractStateProps {';
           final originalPublicClassLine = 'class AbstractStateProps extends _\$AbstractStateProps with _\$AbstractStatePropsAccessorsMixin {';
           final transformedFooStateLine = 'class AbstractStateProps extends _\$AbstractStateProps';


### PR DESCRIPTION
- [x] Always generate accessors in the consumer-defined props/state class
- [x] Generate static constants in the companion classes that point to the generated static constants on the private, consumer-defined classes
- [x] Tests

@sebastianmalysa-wf 